### PR TITLE
Fix warning about yaml load

### DIFF
--- a/src/thesis/classify.py
+++ b/src/thesis/classify.py
@@ -576,7 +576,7 @@ def main(config_path, warn):
     OUTPUT_DIRECTORY folder where plot(s) will be saved
     """
     with open(config_path, "r") as stream:
-        config = yaml.load(stream)
+        config = yaml.load(stream, Loader=yaml.FullLoader)
 
     if warn:
         warnings.resetwarnings()

--- a/src/thesis/grid_search.py
+++ b/src/thesis/grid_search.py
@@ -119,7 +119,7 @@ def main(config_path, warn):
     OUTPUT_DIRECTORY folder where plot(s) will be saved
     """
     with open(config_path, "r") as stream:
-        config = yaml.load(stream)
+        config = yaml.load(stream, Loader=yaml.FullLoader)
 
     if warn:
         warnings.resetwarnings()

--- a/src/thesis/visualize_results.py
+++ b/src/thesis/visualize_results.py
@@ -205,7 +205,7 @@ def plot_scores(
 @click.option("--show/--no-show", default=True)
 def main(result_dir, config_file, show):
     with open(Path(result_dir, CONFIG_FILENAME), "r") as stream:
-        classify_config = yaml.load(stream)
+        classify_config = yaml.load(stream, Loader=yaml.FullLoader)
     if config_file:
         with open(config_file, "r") as stream:
             config = yaml.load(stream)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def tiny_csv_filepath(tiny_csv_folder):
 @pytest.fixture
 def classify_config(multiple_csv_files, tmpdir):
     with open("./config/test.yml", "r") as stream:
-        config = yaml.load(stream)
+        config = yaml.load(stream, Loader=yaml.FullLoader)
     config["general"]["data_dir"] = str(multiple_csv_files)
     config["general"]["output_dir"] = str(Path(tmpdir, "output"))
     return config


### PR DESCRIPTION
Use the unsafe loader explicitly as the input data are the configs, which are trusted.