### PR TITLE
Test tensorflow more

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -44,6 +44,7 @@ models-to-run:
   - knn_fastdtw-oned
   - lgbm-finger_own
   - lr-oned_weasel
+  - mlp-finger_relown
   - mlp-tsfresh
   - ott_algo-finger_ott
   - pytsknn-oned
@@ -307,6 +308,19 @@ models:
       variance: True
       rfe:
         features: 20
+
+  mlp-finger_relown:
+    normalize: "zscore"
+    classifier:
+      n_jobs: *n_jobs
+      hidden_layer_sizes: !!python/tuple [4]
+      dropout: 0.01
+      optimizer: "adam"
+      batch_size: *batch_size
+      epochs: *epochs
+      verbose: *verbose
+    grid:
+      classifier: *mlp_grid
 
   mlp-finger_all:
     normalize: "zscore"


### PR DESCRIPTION
The reason: It should be ensured that the Tensorflow upgrade to 2.5.1 will not break any features/behavior.